### PR TITLE
Add support for multiple #import in the same file in schema files

### DIFF
--- a/plugin/customImport.js
+++ b/plugin/customImport.js
@@ -15,7 +15,10 @@ export function getSources(filepath, resolve, acc = []) {
   const nestedPaths = getFilepaths(importSrc, filepath, resolve)
   const srcs =
     nestedPaths.length > 0
-      ? nestedPaths.reduce((srcArr, fp) => [...srcArr, ...getSources(fp, resolve, [importSrc])], [])
+      ? [
+          ...nestedPaths.reduce((srcArr, fp) => [...srcArr, ...getSources(fp, resolve, [])], []),
+          importSrc
+        ]
       : [importSrc]
   return [...srcs, ...acc]
 }

--- a/tests/__snapshots__/requireGql.test.js.snap
+++ b/tests/__snapshots__/requireGql.test.js.snap
@@ -23,9 +23,14 @@ exports[`parse schema file at runtime concatenates multiple levels of #imported 
 "type LevelTwo {
   test: String!
 }
+type LevelTwoBis {
+  test: String!
+}
+
 
 type LevelOne {
   levelTwo: LevelTwo
+  levelTwoBis: LevelTwoBis
 }
 
 type Query {

--- a/tests/fixtures/requireGql/customImport/levelOne.graphql
+++ b/tests/fixtures/requireGql/customImport/levelOne.graphql
@@ -1,5 +1,7 @@
 #import "./levelTwo.graphql"
+#import "./levelTwoBis.graphql"
 
 type LevelOne {
   levelTwo: LevelTwo
+  levelTwoBis: LevelTwoBis
 }

--- a/tests/fixtures/requireGql/customImport/levelTwoBis.graphql
+++ b/tests/fixtures/requireGql/customImport/levelTwoBis.graphql
@@ -1,0 +1,3 @@
+type LevelTwoBis {
+  test: String!
+}


### PR DESCRIPTION
Related to #38 

import was not working when having multiple #import statements in the same file.
Elements defined directly in this file were added multiple times ( one for each import )

This is a proposition of fix this issue. I tried to keep the same spirit of existing code and test.