### PR TITLE
Add support for multiple #import in the same file in schema files for level one

### DIFF
--- a/plugin/requireGql.js
+++ b/plugin/requireGql.js
@@ -19,10 +19,12 @@ export const requireGql = (filepath, { resolve = defaultResolve, nowrap = true }
     if (imports.length === 0) return source
 
     // Resolve all #import statements (types, etc) recursively and concat them to the main source.
-    return imports
-      .reduce((acc, fp) => [...acc, ...customImport.getSources(fp, resolve, [source])], [])
-      .map(stripImportStatements)
-      .join('')
+    return (
+      imports
+        .reduce((acc, fp) => [...acc, ...customImport.getSources(fp, resolve, [])], [])
+        .map(stripImportStatements)
+        .join('') + stripImportStatements(source)
+    )
   }
 
   const doc = processDoc(createDoc(source, filepath, resolve))

--- a/tests/__snapshots__/requireGql.test.js.snap
+++ b/tests/__snapshots__/requireGql.test.js.snap
@@ -32,6 +32,10 @@ type LevelOne {
   levelTwo: LevelTwo
   levelTwoBis: LevelTwoBis
 }
+type LevelOneBis {
+  levelTwo: LevelTwo
+  levelTwoBis: LevelTwoBis
+}
 
 type Query {
   levelOne: LevelOne

--- a/tests/fixtures/requireGql/customImport/chainedImportsSchema.graphql
+++ b/tests/fixtures/requireGql/customImport/chainedImportsSchema.graphql
@@ -1,4 +1,5 @@
 #import "./levelOne.graphql"
+#import "./levelOneBis.graphql"
 
 type Query {
   levelOne: LevelOne

--- a/tests/fixtures/requireGql/customImport/levelOneBis.graphql
+++ b/tests/fixtures/requireGql/customImport/levelOneBis.graphql
@@ -1,0 +1,4 @@
+type LevelOneBis {
+  levelTwo: LevelTwo
+  levelTwoBis: LevelTwoBis
+}


### PR DESCRIPTION
Related to #38

import was not working when having multiple #import statements in the same file at first level.
Elements defined directly in this file were added multiple times ( one for each import )