### PR TITLE
Added option to import custom file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Option | Type | Default | Description
 -|-|-|-
 `nodePath` | String | value of NODE_PATH environment variable | **Intended for use with [react-app-rewire-inline-import-graphql-ast](https://github.com/detrohutt/react-app-rewire-inline-import-graphql-ast)** -- Used to allow resolution of absolute paths to your `.gql`/`.graphql` files. If you already have your `NODE_PATH` variable set in your environment, you don't need to set this option. **Not** currently respected by `#import` syntax.
 `runtime` | Boolean | false | **Enabling this option requires `graphql-tag` to be installed as a peerDependency.** -- Instead of inlining the parsed AST object, which is very large, this option inlines your GraphQL source code along with an import of the `gql` function from `graphql-tag` and parses your GraphQL source code with `gql` at runtime.
+`extensions` | Array | [] | Enables loading GraphQL SDL files that have a custom extension, e.g. '.prisma' 
+
 
 ## For users of create-react-app
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -17,8 +17,11 @@ export default ({ types: t, template }) => ({
       exit(curPath, { opts, file }) {
         const importPath = curPath.node.source.value
         const jsFilename = file.opts.filename
+        let { extensions = [] } = opts
 
-        if (importPath.endsWith('.graphql') || importPath.endsWith('.gql')) {
+        extensions = [...extensions, '.graphql', '.gql']
+
+        if (extensions.some(extension => importPath.endsWith(extension))) {
           if (opts.runtime) {
             try {
               require('graphql-tag')

--- a/tests/fixtures/imports/named/extension.js
+++ b/tests/fixtures/imports/named/extension.js
@@ -1,0 +1,1 @@
+import extension from '../../shared/extension.graph'

--- a/tests/fixtures/shared/extension.graph
+++ b/tests/fixtures/shared/extension.graph
@@ -1,0 +1,3 @@
+query named {
+  test
+}

--- a/tests/imports.test.js
+++ b/tests/imports.test.js
@@ -127,6 +127,18 @@ describe.each([{ runtime: true }, {}])('plugin options = %j', opts => {
     })
   })
 
+  describe('non-standard extension', () => {
+    test(`import extension from 'extension.graph'`, () => {
+      const { code } = transformWithPlugin('./fixtures/imports/named/extension.js', {
+        ...opts,
+        extensions: ['.graph']
+      })
+      let _graphqlTag, _graphqlTag2, extension
+      eval(code)
+      expect(extension.kind).toBe('Document')
+    })
+  })
+
   describe('single fragment document', () => {
     test(`import frag from '../../shared/fragments/fragment.graphql'`, () => {
       const { code } = transformWithPlugin('./fixtures/imports/fragments/simple.js', opts)


### PR DESCRIPTION
As title states, this pull request enables other extensions for loading GraphQL SDL. This is useful for sharing data models made to comply with e.g. Prisma, which uses the standard GraphQL, but a custom file type of .prisma.