### PR TITLE
Support `import * from "..."` syntax

### DIFF
--- a/plugin/constants.js
+++ b/plugin/constants.js
@@ -1,1 +1,3 @@
 export const newlinePattern = /(\r\n|\r|\n)+/
+
+export const importPattern = /^# *?import +?(?:\* +?from +?)?(?:'|"|`)(.+?)(?:'|"|`)(?:\r\n|\r|\n)*$/gm

--- a/plugin/customImport.js
+++ b/plugin/customImport.js
@@ -1,13 +1,19 @@
 import { readFileSync } from 'fs'
 
-import { newlinePattern } from './constants'
+import { newlinePattern, importPattern } from './constants'
 
 export function getFilepaths(src, relFile, resolve) {
-  const imports = src.split(newlinePattern).filter(line => line.startsWith('#import'))
-  return imports.map(statement => {
-    const importPath = statement.split(/[\s\n]+/g)[1].slice(1, -1)
-    return resolve(importPath, relFile)
-  })
+  return src.split(newlinePattern).reduce(
+    (acc, line) => {
+      const matches = importPattern.exec(line)
+      if (matches) {
+        const [, importPath] = matches
+        acc.push(resolve(importPath, relFile))
+      }
+      return acc
+    },
+    []
+  )
 }
 
 export function getSources(filepath, resolve, acc = []) {

--- a/plugin/customImport.js
+++ b/plugin/customImport.js
@@ -22,9 +22,9 @@ export function getSources(filepath, resolve, acc = []) {
   const srcs =
     nestedPaths.length > 0
       ? [
-          ...nestedPaths.reduce((srcArr, fp) => [...srcArr, ...getSources(fp, resolve, [])], []),
-          importSrc
-        ]
+        ...nestedPaths.reduce((srcArr, fp) => [...srcArr, ...getSources(fp, resolve, [])], []),
+        importSrc
+      ]
       : [importSrc]
   return [...srcs, ...acc]
 }

--- a/plugin/requireGql.js
+++ b/plugin/requireGql.js
@@ -3,7 +3,7 @@ import path, { isAbsolute, join, dirname } from 'path'
 import gql from 'graphql-tag'
 
 import { createDocPerOp } from './multiOp'
-import { newlinePattern } from './constants'
+import { newlinePattern, importPattern } from './constants'
 import * as customImport from './customImport'
 
 export const defaultResolve = (src, file) => path.resolve(dirname(file), src)
@@ -57,10 +57,7 @@ function isSchemaLike(source) {
 }
 
 function stripImportStatements(src) {
-  return src
-    .split(newlinePattern)
-    .filter(line => !line.startsWith('#import'))
-    .join('')
+  return src.replace(importPattern, '')
 }
 
 function createDoc(source, filepath, resolve) {

--- a/tests/__snapshots__/requireGql.test.js.snap
+++ b/tests/__snapshots__/requireGql.test.js.snap
@@ -40,6 +40,7 @@ type LevelOneBis {
 type Query {
   levelOne: LevelOne
 }
+
 schema {
   query: Query
 }


### PR DESCRIPTION
The point of this is to match the syntax that [`graphql-import`](https://github.com/prisma/graphql-import) supports so tools like [`graphql-code-generator`](https://github.com/dotansimha/graphql-code-generator) can be used on the same code that `babel-plugin-import-graphql` transpiles.

Tangentially, I wonder if it makes sense to use [`graphql-import`](https://github.com/prisma/graphql-import) to do all of the resolution of imports.