### PR TITLE
Update kind-of version in yarn, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,23 @@ Congratulations, you're all set!
 
 ## Prerequisites
 
-* `babel-core@^6.26.3` or `@babel/core@^7.0.0-beta.40` (Lower betas may work but weren't tested)
+* `babel-core@^7.20.7` or `@babel/core@^7.0.0-beta.49` (Lower betas may work but weren't tested)
 
-* `graphql-tag@^2.1.0` (only if using the `runtime` option described below)
+* `graphql-tag@^2.9.2` (only if using the `runtime` option described below)
 
 ## Install
 
 ```bash
-$ yarn add -D babel-plugin-import-graphql
+yarn add -D babel-plugin-import-graphql
+```
+or
+```bash
+npm i -D babel-plugin-import-graphql
 ```
 
 In `.babelrc` file:
 
-```JSON
+```json
 {
   "plugins": ["import-graphql"]
 }
@@ -67,7 +71,7 @@ Each time you modify a GraphQL file, the cache must be cleared for the changes t
 
 If using node then the `node_modules/.cache/babel-loader` folder must be cleared. I recommend prepending the relevant script in your `package.json` and rerunning the script when you change a GraphQL file:
 
-```JSON
+```json
 {
   "scripts": {
     "start": "rm -rf ./node_modules/.cache/babel-loader && node index.js"
@@ -85,7 +89,7 @@ react-native start --reset-cache
 
 ## Basic Usage
 
-```JavaScript
+```js
 ...
 import myQuery from './query.graphql'
 ...
@@ -118,7 +122,7 @@ Named imports | All operations/fragments, **including the default**, act as name
 
 ProductsPage.js
 
-```JSX
+```jsx
 import React, { Component } from 'react'
 import gql from 'graphql-tag'
 import { graphql } from 'react-apollo'
@@ -148,7 +152,7 @@ export default graphql(productsQuery)(ProductsPage)
 
 productFragment.graphql
 
-```GraphQL
+```gql
 fragment productFragment on Product {
   name
   description
@@ -158,7 +162,7 @@ fragment productFragment on Product {
 
 productsQuery.graphql
 
-```GraphQL
+```gql
 #import "./productFragment.graphql"
 query products {
   products {
@@ -170,7 +174,7 @@ query products {
 
 ProductsPage.js
 
-```JSX
+```jsx
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo'
 import myImportedQuery from './productsQuery.graphql'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,7 +1683,7 @@ braces@^2.3.1:
     extend-shallow "^2.0.1"
     fill-range "^4.0.0"
     isobject "^3.0.1"
-    kind-of "^6.0.2"
+    kind-of "^6.0.3"
     repeat-element "^1.1.2"
     snapdragon "^0.8.1"
     snapdragon-node "^2.0.1"
@@ -2553,7 +2553,7 @@ has-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
   dependencies:
     is-number "^3.0.0"
-    kind-of "^4.0.0"
+    kind-of "^6.0.3"
 
 has@^1.0.1:
   version "1.0.1"
@@ -2651,13 +2651,13 @@ is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
   dependencies:
-    kind-of "^3.0.2"
+    kind-of "^6.0.3"
 
 is-accessor-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
   dependencies:
-    kind-of "^6.0.0"
+    kind-of "^6.0.3"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2695,13 +2695,13 @@ is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
   dependencies:
-    kind-of "^3.0.2"
+    kind-of "^6.0.3"
 
 is-data-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
-    kind-of "^6.0.0"
+    kind-of "^6.0.3"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2709,7 +2709,7 @@ is-descriptor@^0.1.0:
   dependencies:
     is-accessor-descriptor "^0.1.6"
     is-data-descriptor "^0.1.4"
-    kind-of "^5.0.0"
+    kind-of "^6.0.3"
 
 is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
@@ -2717,7 +2717,7 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   dependencies:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
-    kind-of "^6.0.2"
+    kind-of "^6.0.3"
 
 is-directory@^0.3.1:
   version "0.3.1"
@@ -2767,7 +2767,7 @@ is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
-    kind-of "^3.0.2"
+    kind-of "^6.0.3"
 
 is-number@^4.0.0:
   version "4.0.0"
@@ -3579,7 +3579,7 @@ micromatch@^3.1.8:
     extend-shallow "^3.0.2"
     extglob "^2.0.4"
     fragment-cache "^0.2.1"
-    kind-of "^6.0.2"
+    kind-of "^6.0.3"
     nanomatch "^1.2.9"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
@@ -3629,7 +3629,7 @@ nanomatch@^1.2.9:
     fragment-cache "^0.2.1"
     is-odd "^2.0.0"
     is-windows "^1.0.2"
-    kind-of "^6.0.2"
+    kind-of "^6.0.3"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
@@ -3700,7 +3700,7 @@ object-copy@^0.1.0:
   dependencies:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
-    kind-of "^3.0.3"
+    kind-of "^6.0.3"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4266,7 +4266,7 @@ snapdragon-util@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
   dependencies:
-    kind-of "^3.2.0"
+    kind-of "^6.0.3"
 
 snapdragon@^0.8.1:
   version "0.8.2"
@@ -4500,7 +4500,7 @@ to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
   dependencies:
-    kind-of "^3.0.2"
+    kind-of "^6.0.3"
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -4602,7 +4602,7 @@ use@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
-    kind-of "^6.0.2"
+    kind-of "^6.0.3"
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
Updated versions referenced in docs and some adjusts in rendering codes.

In yarn.lock the dependency `kind-of` was updated to last one because of vulnerability issues appointed.